### PR TITLE
Do not skip serializing number of cells for VTU output

### DIFF
--- a/src/xml.rs
+++ b/src/xml.rs
@@ -1454,18 +1454,13 @@ impl From<Extent> for model::Extent {
     }
 }
 
-// Helper for serializing number_of_cells
-fn is_zero(n: &u32) -> bool {
-    *n == 0
-}
-
 #[derive(Clone, Debug, PartialEq, Default, Serialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct Piece {
     pub extent: Option<Extent>,
     #[serde(default)]
     pub number_of_points: u32,
-    #[serde(default, skip_serializing_if = "is_zero")]
+    #[serde(default)]
     pub number_of_cells: u32,
     #[serde(default)]
     pub number_of_lines: u32,


### PR DESCRIPTION
ParaView and meshio complain when NumberOfCells="0" is missing in the output XML. I'm not sure what the reason is for skipping it, but apparently *not* skipping the serialization is sufficient to fix ParaView. meshio seems to have other troubles. I glanced at the code of `meshio` and it *might* just be that their logic is broken for empty meshes. I'm not entirely sure as I'm not so fluent in the style of Python they use.

I wanted to add a test but I couldn't quite figure out the structure of tests, i.e. where to put it, and how best to create a test like this. With some hints I might be able to do that.