### PR TITLE
deps: Update to num-derive 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ travis-ci = { repository = "elrnv/vtkio", branch = "master" }
 [dependencies]
 nom = "7"
 num-traits = "0.2"
-num-derive = "0.3"
+num-derive = "0.4"
 byteorder = "1.3"
 base64 = "0.21"
 bytemuck = { version = "1.5", features = ["extern_crate_alloc"] }


### PR DESCRIPTION
This removes usage of `syn 1.x`.