### PR TITLE
deps: Update `lz4_flex`, `base64`, `env_logger`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ nom = "7"
 num-traits = "0.2"
 num-derive = "0.4"
 byteorder = "1.3"
-base64 = "0.21"
+base64 = "0.22"
 bytemuck = { version = "1.5", features = ["extern_crate_alloc"] }
-lz4 = { package = "lz4_flex", version = "0.10", optional = true }
+lz4 = { package = "lz4_flex", version = "0.11", optional = true }
 flate2 = { version = "1.0.19", optional = true }
 xz2 = { version = "0.1.6", optional = true } # LZMA
 # quick-xml = { path = "../quick-xml", features = ["serialize", "binary"], optional = true }
@@ -33,7 +33,7 @@ log = "0.4"
 [dev-dependencies]
 regex = "1.0"
 pretty_assertions = "1.0"
-env_logger = "0.10"
+env_logger = "0.11"
 
 [features]
 default = ["xml", "compression"]


### PR DESCRIPTION
This doesn't update `quick-xml` as it doesn't pass tests.