### PR TITLE
Add check for empty polydata topology

### DIFF
--- a/src/xml.rs
+++ b/src/xml.rs
@@ -2574,42 +2574,74 @@ impl TryFrom<VTKFile> for model::Vtk {
                                 + number_of_strips
                                 + number_of_polys
                                 + number_of_verts;
-                            let verts = verts
-                                .map(|verts| {
-                                    verts.into_vertex_numbers(
-                                        number_of_verts,
-                                        appended_data,
-                                        encoding_info,
-                                    )
-                                })
-                                .transpose()?;
-                            let lines = lines
-                                .map(|lines| {
-                                    lines.into_vertex_numbers(
-                                        number_of_lines,
-                                        appended_data,
-                                        encoding_info,
-                                    )
-                                })
-                                .transpose()?;
-                            let strips = strips
-                                .map(|strips| {
-                                    strips.into_vertex_numbers(
-                                        number_of_strips,
-                                        appended_data,
-                                        encoding_info,
-                                    )
-                                })
-                                .transpose()?;
-                            let polys = polys
-                                .map(|polys| {
-                                    polys.into_vertex_numbers(
-                                        number_of_polys,
-                                        appended_data,
-                                        encoding_info,
-                                    )
-                                })
-                                .transpose()?;
+                            let verts = match verts {
+                                Some(Topo {
+                                    ref connectivity,
+                                    ref offsets,
+                                }) if !connectivity.data.is_empty() && !offsets.data.is_empty() => {
+                                    verts
+                                        .map(|verts| {
+                                            verts.into_vertex_numbers(
+                                                number_of_verts,
+                                                appended_data,
+                                                encoding_info,
+                                            )
+                                        })
+                                        .transpose()?
+                                }
+                                _ => None,
+                            };
+                            let lines = match lines {
+                                Some(Topo {
+                                    ref connectivity,
+                                    ref offsets,
+                                }) if !connectivity.data.is_empty() && !offsets.data.is_empty() => {
+                                    lines
+                                        .map(|lines| {
+                                            lines.into_vertex_numbers(
+                                                number_of_lines,
+                                                appended_data,
+                                                encoding_info,
+                                            )
+                                        })
+                                        .transpose()?
+                                }
+                                _ => None,
+                            };
+                            let strips = match strips {
+                                Some(Topo {
+                                    ref connectivity,
+                                    ref offsets,
+                                }) if !connectivity.data.is_empty() && !offsets.data.is_empty() => {
+                                    strips
+                                        .map(|strips| {
+                                            strips.into_vertex_numbers(
+                                                number_of_strips,
+                                                appended_data,
+                                                encoding_info,
+                                            )
+                                        })
+                                        .transpose()?
+                                }
+                                _ => None,
+                            };
+                            let polys = match polys {
+                                Some(Topo {
+                                    ref connectivity,
+                                    ref offsets,
+                                }) if !connectivity.data.is_empty() && !offsets.data.is_empty() => {
+                                    polys
+                                        .map(|polys| {
+                                            polys.into_vertex_numbers(
+                                                number_of_polys,
+                                                appended_data,
+                                                encoding_info,
+                                            )
+                                        })
+                                        .transpose()?
+                                }
+                                _ => None,
+                            };
                             Ok(model::Piece::Inline(Box::new(model::PolyDataPiece {
                                 points: points.unwrap().data.into_io_buffer(
                                     number_of_points,

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -2574,74 +2574,42 @@ impl TryFrom<VTKFile> for model::Vtk {
                                 + number_of_strips
                                 + number_of_polys
                                 + number_of_verts;
-                            let verts = match verts {
-                                Some(Topo {
-                                    ref connectivity,
-                                    ref offsets,
-                                }) if !connectivity.data.is_empty() && !offsets.data.is_empty() => {
-                                    verts
-                                        .map(|verts| {
-                                            verts.into_vertex_numbers(
-                                                number_of_verts,
-                                                appended_data,
-                                                encoding_info,
-                                            )
-                                        })
-                                        .transpose()?
-                                }
-                                _ => None,
-                            };
-                            let lines = match lines {
-                                Some(Topo {
-                                    ref connectivity,
-                                    ref offsets,
-                                }) if !connectivity.data.is_empty() && !offsets.data.is_empty() => {
-                                    lines
-                                        .map(|lines| {
-                                            lines.into_vertex_numbers(
-                                                number_of_lines,
-                                                appended_data,
-                                                encoding_info,
-                                            )
-                                        })
-                                        .transpose()?
-                                }
-                                _ => None,
-                            };
-                            let strips = match strips {
-                                Some(Topo {
-                                    ref connectivity,
-                                    ref offsets,
-                                }) if !connectivity.data.is_empty() && !offsets.data.is_empty() => {
-                                    strips
-                                        .map(|strips| {
-                                            strips.into_vertex_numbers(
-                                                number_of_strips,
-                                                appended_data,
-                                                encoding_info,
-                                            )
-                                        })
-                                        .transpose()?
-                                }
-                                _ => None,
-                            };
-                            let polys = match polys {
-                                Some(Topo {
-                                    ref connectivity,
-                                    ref offsets,
-                                }) if !connectivity.data.is_empty() && !offsets.data.is_empty() => {
-                                    polys
-                                        .map(|polys| {
-                                            polys.into_vertex_numbers(
-                                                number_of_polys,
-                                                appended_data,
-                                                encoding_info,
-                                            )
-                                        })
-                                        .transpose()?
-                                }
-                                _ => None,
-                            };
+                            let verts = verts
+                                .map(|verts| {
+                                    verts.into_vertex_numbers(
+                                        number_of_verts,
+                                        appended_data,
+                                        encoding_info,
+                                    )
+                                })
+                                .transpose()?;
+                            let lines = lines
+                                .map(|lines| {
+                                    lines.into_vertex_numbers(
+                                        number_of_lines,
+                                        appended_data,
+                                        encoding_info,
+                                    )
+                                })
+                                .transpose()?;
+                            let strips = strips
+                                .map(|strips| {
+                                    strips.into_vertex_numbers(
+                                        number_of_strips,
+                                        appended_data,
+                                        encoding_info,
+                                    )
+                                })
+                                .transpose()?;
+                            let polys = polys
+                                .map(|polys| {
+                                    polys.into_vertex_numbers(
+                                        number_of_polys,
+                                        appended_data,
+                                        encoding_info,
+                                    )
+                                })
+                                .transpose()?;
                             Ok(model::Piece::Inline(Box::new(model::PolyDataPiece {
                                 points: points.unwrap().data.into_io_buffer(
                                     number_of_points,


### PR DESCRIPTION
When parsing a .vtp file using vtkio the program crashed with this error message:

```
The application panicked (crashed).
Message:  index out of bounds: the len is 0 but the index is 0
Location: /home/maik/Rust/vtkio/src/xml.rs:1569
```

The problem was that the data vector is always used, even if the vector is empty but still Some. This happened for my files when the different types of topology are specified in the file but don't contain any data. E.g. like this:

```
      <Polys>
        <DataArray type="Int64" Name="connectivity" format="ascii" RangeMin="0" RangeMax="95">
        </DataArray>
        <DataArray type="Int64" Name="offsets" format="ascii" RangeMin="28" RangeMax="96">
        </DataArray>
      </Polys>
```
So I added a check that also returns None if the Vectors of offset or connectivity are empty.