### PR TITLE
Add `num_cells` variable to `write_attributes()` function for SGrids

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -724,9 +724,9 @@ mod write_vtk_impl {
                                 EntryPart::Data(e.into()),
                             )))
                         })?;
-
+                        let num_cells = ((dims[0] - 1) * (dims[1] - 1) * (dims[2] - 1)) as usize;
                         assert_eq!((dims[0] * dims[1] * dims[2]) as usize, num_points);
-                        self.write_attributes::<BO>(data, num_points, 1)?;
+                        self.write_attributes::<BO>(data, num_points, num_cells)?;
                     }
                 }
 


### PR DESCRIPTION
Like described in [this](https://github.com/elrnv/vtkio/issues/48) Issue, the variable `num_cells` contained a constant 1, which led to problems when writing attributes to a vtk file. The value is now calculated using the dimensions of the SGrid.

The value is necessary because it is written to the line 
```
CELL_DATA <value>
```
of the vtk file, which ParaView uses to get the count of attribute values when loading a file. The value has to be equal to the cell count of the SGrid.