### PR TITLE
Recognize ASCII as well as ascii.

### DIFF
--- a/src/xml.rs
+++ b/src/xml.rs
@@ -1772,6 +1772,7 @@ impl From<ScalarType> for model::ScalarType {
 pub enum DataArrayFormat {
     Appended,
     Binary,
+    #[serde(alias = "ascii", alias = "ASCII")]
     Ascii,
 }
 


### PR DESCRIPTION
When parsing a XML `format="ASCII"` is now recognised as well as `format="ascii"`.