### PR TITLE
Upgrade to nom v8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/vtkio"
 keywords = ["vtk", "parser", "writer", "io", "mesh"]
 
 [dependencies]
-nom = "7"
+nom = "8"
 num-traits = "0.2"
 num-derive = "0.4"
 byteorder = "1.3"


### PR DESCRIPTION
I recently did an upgrade to nom v8 in my codebase and thought that I could upgrade the VTK legacy parser as well as it doesn't require that much work compared to the v7 upgrade.

Maybe you can consider publishing a new version at some point without the updated binary support (I guess that this still blocked?) so that we can benefit of the various bug fixes and fixed deprecation warning from the old nom version? 